### PR TITLE
Adding wrap around in settings menu

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -135,7 +135,7 @@ int main(void) {
 	VPBDIV = 0x01; // APB runs at the same frequency as the CPU (55.296MHz)
 	MAMTIM = 0x03; // 3 cycles flash access recommended >40MHz
 	MAMCR = 0x02; // Fully enable memory accelerator
-	
+
 	Sched_Init();
 	IO_Init();
 	Set_Heater(0);
@@ -235,11 +235,19 @@ static int32_t Main_Work( void ) {
 		if( keyrepeataccel < 1) keyrepeataccel = 1;
 		if( keyrepeataccel > 30) keyrepeataccel = 30;
 
-		if(keyspressed & KEY_F1 && selected > 0) { // Prev row
-			selected--;
+		if (keyspressed & KEY_F1) {
+			if (selected > 0) { // Prev row
+				selected--;
+			} else { // wrap
+				selected = NUM_SETUP_ITEMS - 1;
+			}
 		}
-		if(keyspressed & KEY_F2 && selected < (NUM_SETUP_ITEMS-1)) { // Next row
-			selected++;
+		if (keyspressed & KEY_F2) {
+			if (selected < (NUM_SETUP_ITEMS - 1)) { // Next row
+				selected++;
+			} else { // wrap
+				selected = 0;
+			}
 		}
 
 		int curval = NV_GetConfig(setupmenu[selected].nvval);


### PR DESCRIPTION
Received my oven yesterday, flashed the firmware, it works!

So time to try some modifications to the code.
- wrap around is in lines 238-250.
- Tried to clean up the coding style for this method in the process. This should be more consistent. Tell me if you don't like it, but especially the comma's without spaces make the code hard to read.

Unfortunately, after I flashed the new version, the display stays blank. I think it's a hardware issue since I was also screwing the PCB back into the case, so the wraparound code is not tested on an actual device...

