### PR TITLE
Serial setup real value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(BUILD_DIR)%.o: $(SRC_DIR)%.s $(BUILD_DIR)tag
 axf: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
-	$(CC) -nostdlib -Xlinker -Map="$(BUILD_DIR)$(BASE_NAME).map" -Xlinker --gc-sections -flto -Os -mcpu=arm7tdmi --specs=nano.specs -u _printf_float -T "$(BASE_NAME).ld" -o "$(TARGET)" $(OBJS) $(USER_OBJS) $(LIBS)
+	$(CC) -nostdlib -Xlinker -Map="$(BUILD_DIR)$(BASE_NAME).map" -Xlinker --gc-sections -flto -Os -mcpu=arm7tdmi --specs=nano.specs -u _printf_float -u _scanf_float -T "$(BASE_NAME).ld" -o "$(TARGET)" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $(COLOR_GREEN)$@$(COLOR_END)'
 	@echo ' '
 	$(MAKE) --no-print-directory post-build

--- a/src/main.c
+++ b/src/main.c
@@ -171,13 +171,14 @@ static int32_t Main_Work(void) {
 	char serial_cmd[255] = "";
 	char* cmd_select_profile = "select profile %d";
 	char* cmd_bake = "bake %d";
-	char* cmd_setting = "setting %d %d";
+	char* cmd_setting = "setting %d %f";
 
 	if (uart_isrxready()) {
 		int len = uart_readline(serial_cmd, 255);
 
 		if (len > 0) {
 			int param, param1;
+			float paramF;
 
 			if (strcmp(serial_cmd, "about") == 0) {
 				printf(format_about, Version_GetGitVersion());
@@ -226,10 +227,8 @@ static int32_t Main_Work(void) {
 				mode = MAIN_BAKE;
 				Reflow_SetMode(REFLOW_BAKE);
 
-			} else if (sscanf(serial_cmd, cmd_setting, &param, &param1) > 0) {
-				// This is currently a bit crude. User has to input
-				// the value as an integer as stored in the NV storage.
-				Setup_setValue(param, param1);
+			} else if (sscanf(serial_cmd, cmd_setting, &param, &paramF) > 0) {
+				Setup_setRealValue(param, paramF);
 				printf("\nAdjusted setting: ");
 				Setup_printFormattedValue(param);
 

--- a/src/setup.c
+++ b/src/setup.c
@@ -48,6 +48,12 @@ void Setup_setValue(int item, int value) {
 	Reflow_ValidateNV();
 }
 
+void Setup_setRealValue(int item, float value) {
+	int intval = (int)(value / setupmenu[item].multiplier);
+	intval -= setupmenu[item].offset;
+	Setup_setValue(item, intval);
+}
+
 void Setup_increaseValue(int item, int amount) {
 	int curval = Setup_getValue(item) + amount;
 

--- a/src/setup.h
+++ b/src/setup.h
@@ -12,6 +12,7 @@ typedef struct {
 
 int Setup_getNumItems(void);
 float Setup_getValue(int item);
+void Setup_setRealValue(int item, float value);
 void Setup_setValue(int item, int value);
 void Setup_increaseValue(int item, int amount);
 void Setup_decreaseValue(int item, int amount);


### PR DESCRIPTION
Allows floating point value input over serial.

Had to add the `-u _scanf_float` flag to the linker to make this work, which increases the binary size considerably. Not sure if this is worth it, but since it fits...