### PR TITLE
Allow external TC 2/3 to replace 0/1

### DIFF
--- a/src/sensor.c
+++ b/src/sensor.c
@@ -107,6 +107,14 @@ void Sensor_DoConversion(void) {
 		tempvalid |= 0x03;
 		coldjunction = (tccj[0] + tccj[1]) / 2.0f;
 		cjsensorpresent = 1;
+	} else if (tcpresent[2] && tcpresent[3]) {
+		avgtemp = (tctemp[2] + tctemp[3]) / 2.0f;
+		temperature[0] = tctemp[2];
+		temperature[1] = tctemp[3];
+		tempvalid |= 0x03;
+		tempvalid &= ~0x0C;
+		coldjunction = (tccj[2] + tccj[3]) / 2.0f;
+		cjsensorpresent = 1;
 	} else {
 		// If the external TC interface is not present we fall back to the
 		// built-in ADC, with or without compensation


### PR DESCRIPTION
I installed the improved TC interface using the MAX31850K breakout board while installing only two of the four IC's. I don't know how the one-wire protocol works, but the sensors I installed were assigned indices 2 and 3, with 0 and 1 listed as not present. This caused the ADC readings to be used. With this patch, external TC's 2 and 3 will be used if they are present but 0 and 1 are not.
