### PR TITLE
Small fixes for LCD text printing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -118,7 +118,7 @@ int main(void) {
 	LCD_disp_str((uint8_t*)buf, len, 0, 64 - 6, FONT6X6);
 	printf("\nRunning on an %s", buf);
 
-	len = snprintf(buf, sizeof(buf), "%s", Version_GetGitVersion());
+	len = snprintf(buf, 21, "%s", Version_GetGitVersion());
 	LCD_disp_str((uint8_t*)buf, len, 128 - (len * 6), 0, FONT6X6);
 
 	LCD_FB_Update();
@@ -348,7 +348,7 @@ static int32_t Main_Work(void) {
 		len = snprintf(buf, sizeof(buf), "T-962 controller");
 		LCD_disp_str((uint8_t*)buf, len, LCD_ALIGN_CENTER(len), 0, FONT6X6);
 
-		len = snprintf(buf, sizeof(buf), "%s", Version_GetGitVersion());
+		len = snprintf(buf, 21, "%s", Version_GetGitVersion());
 		LCD_disp_str((uint8_t*)buf, len, LCD_ALIGN_CENTER(len), 64 - 6, FONT6X6);
 
 		LCD_BMPDisplay(stopbmp, 127 - 17, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -119,6 +119,8 @@ int main(void) {
 	printf("\nRunning on an %s", buf);
 
 	len = snprintf(buf, sizeof(buf), "%s", Version_GetGitVersion());
+	if (len > 21)
+		len = 21;
 	LCD_disp_str((uint8_t*)buf, len, 128 - (len * 6), 0, FONT6X6);
 
 	LCD_FB_Update();
@@ -349,6 +351,8 @@ static int32_t Main_Work(void) {
 		LCD_disp_str((uint8_t*)buf, len, LCD_ALIGN_CENTER(len), 0, FONT6X6);
 
 		len = snprintf(buf, sizeof(buf), "%s", Version_GetGitVersion());
+		if (len > 21)
+			len = 21;
 		LCD_disp_str((uint8_t*)buf, len, LCD_ALIGN_CENTER(len), 64 - 6, FONT6X6);
 
 		LCD_BMPDisplay(stopbmp, 127 - 17, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -119,8 +119,6 @@ int main(void) {
 	printf("\nRunning on an %s", buf);
 
 	len = snprintf(buf, sizeof(buf), "%s", Version_GetGitVersion());
-	if (len > 21)
-		len = 21;
 	LCD_disp_str((uint8_t*)buf, len, 128 - (len * 6), 0, FONT6X6);
 
 	LCD_FB_Update();
@@ -351,8 +349,6 @@ static int32_t Main_Work(void) {
 		LCD_disp_str((uint8_t*)buf, len, LCD_ALIGN_CENTER(len), 0, FONT6X6);
 
 		len = snprintf(buf, sizeof(buf), "%s", Version_GetGitVersion());
-		if (len > 21)
-			len = 21;
 		LCD_disp_str((uint8_t*)buf, len, LCD_ALIGN_CENTER(len), 64 - 6, FONT6X6);
 
 		LCD_BMPDisplay(stopbmp, 127 - 17, 0);

--- a/src/setup.c
+++ b/src/setup.c
@@ -27,9 +27,9 @@ static setupMenuStruct setupmenu[] = {
 	{"Min fan speed    %4.0f", REFLOW_MIN_FAN_SPEED, 0, 254, 0, 1.0f},
 	{"Cycle done beep %4.1fs", REFLOW_BEEP_DONE_LEN, 0, 254, 0, 0.1f},
 	{"Left TC gain     %1.2f", TC_LEFT_GAIN, 10, 190, 0, 0.01f},
-	{"Left TC offset  %+1.2f", TC_LEFT_OFFSET, 0, 200, -100, 0.25f},
+	{"Left TC offs.  %+1.2f", TC_LEFT_OFFSET, 0, 200, -100, 0.25f},
 	{"Right TC gain    %1.2f", TC_RIGHT_GAIN, 10, 190, 0, 0.01f},
-	{"Right TC offset %+1.2f", TC_RIGHT_OFFSET, 0, 200, -100, 0.25f},
+	{"Right TC offs. %+1.2f", TC_RIGHT_OFFSET, 0, 200, -100, 0.25f},
 };
 #define NUM_SETUP_ITEMS (sizeof(setupmenu) / sizeof(setupmenu[0]))
 


### PR DESCRIPTION
This PR includes two smaller fixes around printing of text.
First fix is resolving buffer overflows when compiling from GIT and Version_GetGitVersion() returns a pretty long string, which overflows the LCD_disp_str buffer (and causes a crash and reset).
The second fix makes some more room in the setup screen so that higher offsets with one digit more can be displayed - previously it crashed for me too for offsets not fitting the screen anymore.
